### PR TITLE
Dungeon meshing

### DIFF
--- a/Source/Barrage/Private/BarrageDispatch.cpp
+++ b/Source/Barrage/Private/BarrageDispatch.cpp
@@ -78,6 +78,11 @@ FBLet UBarrageDispatch::CreateSimPrimitive(FBShapeParams& Definition, uint64 Out
 	return indirect;
 }
 
+FBLet UBarrageDispatch::LoadStaticMesh(FBShapeParams& Definition, uint64 Outkey)
+{
+	return FBLet();
+}
+
 //unlike our other ecs components in artillery, barrage dispatch does not maintain the mappings directly.
 //this is because we may have _many_ jolt sims running if we choose to do deterministic rollback in certain ways.
 //This is a copy by value return on purpose, as we want the ref count to rise.

--- a/Source/Barrage/Private/BarrageDispatch.cpp
+++ b/Source/Barrage/Private/BarrageDispatch.cpp
@@ -2,6 +2,7 @@
 #include "FWorldSimOwner.h"
 #include "Chaos/TriangleMeshImplicitObject.h"
 #include "Chaos/TriangleMesh.h"
+#include "Jolt/Physics/Collision/Shape/MeshShape.h"
 #include "PhysicsEngine/BodySetup.h"
 #include "Runtime/Experimental/Chaos/Private/Chaos/PhysicsObjectInternal.h"
 
@@ -138,13 +139,18 @@ FBLet UBarrageDispatch::LoadStaticMeshLoadStaticMesh(FBShapeParams& Definition,
 		//like terrain, this can be extremely significant. though, it's not truly clear to me if it's worth it.
 		auto& VertToTriMap = Mesh->Elements();
 		auto& Verts = Mesh->Particles().X();
-		//this code unpacks the indexed tries, but we can actually just cross load them and save a bunch of allocs.
 		for(auto& aTri : VertToTriMap)
 		{
-			JoltIndexedTriangles.push_back(IndexedTriangle());
+			JoltIndexedTriangles.push_back(IndexedTriangle(aTri[2], aTri[1], aTri[0]));
+		}
+		for(auto& vtx : Verts)
+		{
+			JoltVerts.push_back(Float3(vtx.X/100.0, vtx.Z/100.0, vtx.Y/100.0));
 		}
 	}
-	
+	JPH::MeshShapeSettings FullMesh(JoltVerts, JoltIndexedTriangles);
+	//just the last boiler plate for now.
+
 	/*
 	    case PhysCollision::TYPE_TRIMESH:
     {

--- a/Source/Barrage/Public/BarrageDispatch.h
+++ b/Source/Barrage/Public/BarrageDispatch.h
@@ -69,6 +69,7 @@ public:
 	static FQuat4d FromJoltRotation(FQuat4d In);
 	virtual void SphereCast(double Radius, FVector3d CastFrom, uint64_t timestamp = 0);
 	FBLet CreateSimPrimitive(FBShapeParams& Definition, uint64 Outkey);
+	FBLet LoadStaticMesh(FBShapeParams& Definition, uint64 Outkey);
 	FBLet GetShapeRef(FBarrageKey Existing);
 	void FinalizeReleasePrimitive(FBarrageKey BarrageKey);
 

--- a/Source/Barrage/Public/BarrageDispatch.h
+++ b/Source/Barrage/Public/BarrageDispatch.h
@@ -69,7 +69,7 @@ public:
 	static inline FQuat4d FromJoltRotation(FQuat4d In);
 	virtual void SphereCast(double Radius, FVector3d CastFrom, uint64_t timestamp = 0);
 	FBLet CreateSimPrimitive(FBShapeParams& Definition, uint64 Outkey);
-	FBLet LoadStaticMeshLoadStaticMesh(FBShapeParams& Definition, const UStaticMeshComponent* StaticMeshComponent, uint64 Outkey);
+	FBLet LoadStaticMeshLoadStaticMesh(FBShapeParams& Definition, const UStaticMeshComponent* StaticMeshComponent, uint64 Outkey, FBarrageKey InKey);
 	FBLet GetShapeRef(FBarrageKey Existing);
 	void FinalizeReleasePrimitive(FBarrageKey BarrageKey);
 
@@ -101,7 +101,7 @@ protected:
 	friend FBLetter;
 
 private:
-	TSharedPtr<TMap<FBarrageKey, FBLet>> MasterRecordForLifecycle;
+	TSharedPtr<TMap<FBarrageKey, FBLet>> BodyLifecycleOwner;
 
 	uint32 TombOffset = 0; //ticks up by one every world step.
 	//this is a little hard to explain. so keys are inserted as 
@@ -122,7 +122,7 @@ private:
 	void Entomb(FBLet NONREFERENCE)
 	{
 		//request removal here
-		MasterRecordForLifecycle->Remove(NONREFERENCE->KeyIntoBarrage);
+		BodyLifecycleOwner->Remove(NONREFERENCE->KeyIntoBarrage);
 		// there doesn't seem to be a better way to do this idiomatically in the UE framework.
 		//push into tomb here. because we shadow two back on the release, this is guaranteed to be safe,
 		Tombs[TombOffset]->Push(NONREFERENCE);

--- a/Source/Barrage/Public/BarrageDispatch.h
+++ b/Source/Barrage/Public/BarrageDispatch.h
@@ -63,10 +63,10 @@ public:
 	virtual void OnWorldBeginPlay(UWorld& InWorld) override;
 	virtual void Deinitialize() override;
 
-	static FVector3d ToJoltCoordinates(FVector3d In);
-	static FVector3d FromJoltCoordinates(FVector3d In);
-	static FQuat4d ToJoltRotation(FQuat4d In);
-	static FQuat4d FromJoltRotation(FQuat4d In);
+	static inline FVector3d ToJoltCoordinates(FVector3d In);
+	static inline FVector3d FromJoltCoordinates(FVector3d In);
+	static inline FQuat4d ToJoltRotation(FQuat4d In);
+	static inline FQuat4d FromJoltRotation(FQuat4d In);
 	virtual void SphereCast(double Radius, FVector3d CastFrom, uint64_t timestamp = 0);
 	FBLet CreateSimPrimitive(FBShapeParams& Definition, uint64 Outkey);
 	FBLet LoadStaticMeshLoadStaticMesh(FBShapeParams& Definition, const UStaticMeshComponent* StaticMeshComponent, uint64 Outkey);

--- a/Source/Barrage/Public/BarrageDispatch.h
+++ b/Source/Barrage/Public/BarrageDispatch.h
@@ -69,7 +69,7 @@ public:
 	static FQuat4d FromJoltRotation(FQuat4d In);
 	virtual void SphereCast(double Radius, FVector3d CastFrom, uint64_t timestamp = 0);
 	FBLet CreateSimPrimitive(FBShapeParams& Definition, uint64 Outkey);
-	FBLet LoadStaticMesh(FBShapeParams& Definition, uint64 Outkey);
+	FBLet LoadStaticMeshLoadStaticMesh(FBShapeParams& Definition, const UStaticMeshComponent* StaticMeshComponent, uint64 Outkey);
 	FBLet GetShapeRef(FBarrageKey Existing);
 	void FinalizeReleasePrimitive(FBarrageKey BarrageKey);
 

--- a/Source/Barrage/Public/FBShapeParams.h
+++ b/Source/Barrage/Public/FBShapeParams.h
@@ -19,7 +19,8 @@ struct FBShapeParams
 	{
 		Capsule,
 		Box,
-		Sphere
+		Sphere,
+		Static
 	};
 
 	//All shapes can be defined using just these bounds. actually, this is more than you need for a sphere but hey


### PR DESCRIPTION
Static mesh creation unfortunately needs to live at the Barrage dispatch level, as there's just not really a good way to access everything you end up needing from inside the SimOwner. This might be a bit of a recurrent issue, interestingly. 

We should also consider adopting the shape cache that Andrea's code uses, but I have some ideas for optimizations there.