### PR TITLE
Removes creation of sphere fiblet since we don't need it for the sphe…

### DIFF
--- a/Source/Barrage/Private/BarrageDispatch.cpp
+++ b/Source/Barrage/Private/BarrageDispatch.cpp
@@ -98,10 +98,6 @@ FBLet* UBarrageDispatch::SphereCast(
 		auto bodyID = HoldOpen->BarrageToJoltMapping->Find(ShapeSource);
 		FBarrageKey HitBarrageKey = HoldOpen->SphereCast(Radius, Distance, CastFrom, Direction, *bodyID);
 		return JoltBodyLifecycleMapping->Find(HitBarrageKey);
-		// if (HitFiblet) {
-		// 	return 
-		// 	UE_LOG(LogTemp, Warning, TEXT("Hit a fiblet!"));
-		// }
 	}
 	return nullptr;
 }


### PR DESCRIPTION
…recast

Grab FBarrageKey of ProbablyOwner and use that as the ignore parameter for SphereCast

Dead code cleanup

Adds parameter to BeamCannon to allow adjustable range