### PR TITLE
Reworks SphereCast to use FHitResult out parameter

### DIFF
--- a/Source/Barrage/Private/BarrageDispatch.cpp
+++ b/Source/Barrage/Private/BarrageDispatch.cpp
@@ -84,27 +84,20 @@ void UBarrageDispatch::Deinitialize()
 	HoldOpen = nullptr;
 }
 
-FBLet* UBarrageDispatch::SphereCast(
+void UBarrageDispatch::SphereCast(
 	FBarrageKey ShapeSource,
 	double Radius,
 	double Distance,
 	FVector3d CastFrom,
 	FVector3d Direction,
+	TSharedPtr<FHitResult> OutHit,
 	uint64_t timestamp)
 {
-	UE_LOG(LogTemp, Warning, TEXT("Firing SphereCast, Radius (%f), Distance (%f)"), Radius, Distance);
-
 	auto HoldOpen = JoltGameSim;
 	if (HoldOpen) {
 		auto bodyID = HoldOpen->BarrageToJoltMapping->Find(ShapeSource);
-		FBarrageKey HitBarrageKey = HoldOpen->SphereCast(Radius, Distance, CastFrom, Direction, *bodyID);
-		return JoltBodyLifecycleMapping->Find(HitBarrageKey);
-		// if (HitFiblet) {
-		// 	return 
-		// 	UE_LOG(LogTemp, Warning, TEXT("Hit a fiblet!"));
-		// }
+		HoldOpen->SphereCast(Radius, Distance, CastFrom, Direction, *bodyID, OutHit);
 	}
-	return nullptr;
 }
 
 //Defactoring the pointer management has actually made this much clearer than I expected.
@@ -342,6 +335,15 @@ void UBarrageDispatch::StepWorld(uint64 Time)
 	}
 }
 
+FBarrageKey UBarrageDispatch::GenerateBarrageKeyFromBodyId(const JPH::BodyID& Input) const
+{
+	return JoltGameSim->GenerateBarrageKeyFromBodyId(Input);
+};
+
+FBarrageKey UBarrageDispatch::GenerateBarrageKeyFromBodyId(const uint32 RawIndexAndSequenceNumberInput) const
+{
+	return JoltGameSim->GenerateBarrageKeyFromBodyId(RawIndexAndSequenceNumberInput);
+};
 
 //Bounds are OPAQUE. do not reference them. they are protected for a reason, because they are
 //subject to semantic changes. the Point is left in the UE space. 

--- a/Source/Barrage/Public/BarrageDispatch.h
+++ b/Source/Barrage/Public/BarrageDispatch.h
@@ -72,7 +72,7 @@ public:
 	virtual void Deinitialize() override;
 
 
-	virtual FBLet* SphereCast(FBarrageKey ShapeSource, double Radius, double Distance, FVector3d CastFrom, FVector3d Direction, uint64_t timestamp = 0);
+	virtual void SphereCast(FBarrageKey ShapeSource, double Radius, double Distance, FVector3d CastFrom, FVector3d Direction, TSharedPtr<FHitResult> OutHit, uint64_t timestamp = 0);
 	//and viola [sic] actually pretty elegant even without type polymorphism by using overloading polymorphism.
 	FBLet CreatePrimitive(FBBoxParams& Definition, FSkeletonKey Outkey, uint16 Layer);
 	FBLet CreatePrimitive(FBCharParams& Definition, FSkeletonKey Outkey, uint16 Layer);
@@ -113,6 +113,9 @@ public:
 	//ONLY call this from a thread OTHER than gamethread, or you will experience untold sorrow.
 	void StepWorld(uint64 Time);
 
+	FBarrageKey GenerateBarrageKeyFromBodyId(const JPH::BodyID& Input) const;
+	FBarrageKey GenerateBarrageKeyFromBodyId(const uint32 RawIndexAndSequenceNumberInput) const;
+	
 protected:
 
 private:

--- a/Source/Barrage/Public/CastShapeCollectors/SphereCastCollector.h
+++ b/Source/Barrage/Public/CastShapeCollectors/SphereCastCollector.h
@@ -36,7 +36,7 @@ public:
 	}
 
 	// Configuration
-	JPH::PhysicsSystem &		mPhysicsSystem;
+	JPH::PhysicsSystem &	mPhysicsSystem;
 	const JPH::RShapeCast &	mShapeCast;
 
 	// Resulting closest collision

--- a/Source/Barrage/Public/FWorldSimOwner.h
+++ b/Source/Barrage/Public/FWorldSimOwner.h
@@ -8,14 +8,12 @@
 #include "BarrageDispatch.h"
 #include "Containers/CircularQueue.h"
 #include "Chaos/TriangleMeshImplicitObject.h"
-#include "CoordinateUtils.h"
 #include "FBShapeParams.h"
 #include "FBarrageKey.h"
 #include "FBPhysicsInput.h"
 
 #include "SkeletonTypes.h"
 #include "IsolatedJoltIncludes.h"
-#include "PhysicsEngine/BodySetup.h"
 
 // All Jolt symbols are in the JPH namespace
 
@@ -312,7 +310,7 @@ public:
 	TSharedPtr<PhysicsSystem> physics_system;
 	FWorldSimOwner(float cDeltaTime);
 
-	FBarrageKey SphereCast(double Radius, double Distance, FVector3d CastFrom, FVector3d Direction, JPH::BodyID& CastingBody);
+	void SphereCast(double Radius, double Distance, FVector3d CastFrom, FVector3d Direction, JPH::BodyID& CastingBody, TSharedPtr<FHitResult> OutHit) const;
 	
 	//we could use type indirection or inheritance, but the fact of the matter is that this is much easier
 	//to understand and vastly vastly faster. it's also easier to optimize out allocations, and it's very
@@ -347,6 +345,7 @@ public:
 		}
 	}
 	FBarrageKey GenerateBarrageKeyFromBodyId(const BodyID& Input) const;
+	FBarrageKey GenerateBarrageKeyFromBodyId(const uint32 RawIndexAndSequenceNumberInput) const;
 	~FWorldSimOwner();
 	bool UpdateCharacter(FBPhysicsInput& Update);
 	bool UpdateCharacters(TSharedPtr<TArray<FBPhysicsInput>> Array);


### PR DESCRIPTION
* NOTE: We munge the `BodyID` of the hit object into `FHitResult::MyItem` as we do not have enough bit space to store the 64 bit BarrageKey without additional munging. We likely should add some utility to make getting a `FBLet` or other information out of an `FHitResult` Further munging would require using `FHitResult::Item`, which is next to `MyItem` in the structure and would give us the full 64 bits.

Exposes `FWorldSimOwner::GenerateBarrageKeyFromBodyId` through `UBarrageDispatch::GenerateBarrageKeyFromBodyId`

Reformats code to be more in line with other lib files