### PR TITLE
Adds initial pass of reticle friction when aiming at an enemy

### DIFF
--- a/Source/Barrage/Public/BarrageDispatch.h
+++ b/Source/Barrage/Public/BarrageDispatch.h
@@ -127,6 +127,12 @@ public:
 
 	FBarrageKey GenerateBarrageKeyFromBodyId(const JPH::BodyID& Input) const;
 	FBarrageKey GenerateBarrageKeyFromBodyId(const uint32 RawIndexAndSequenceNumberInput) const;
+
+	FBarrageKey GetBarrageKeyFromFHitResult(TSharedPtr<FHitResult> HitResult) const
+	{
+		check(HitResult.IsValid());
+		return HitResult.Get()->MyItem != JPH::BodyID::cInvalidBodyID ? GenerateBarrageKeyFromBodyId(static_cast<uint32>(HitResult.Get()->MyItem)) : 0;
+	}
 	
 protected:
 


### PR DESCRIPTION
Adds helper function to `BarrageDispatch.h` to fetch an `FBarrageKey` from a `FHitResult`

Updates Bristle54Enemy asset to have "enemy" tag

Adds Player ActorKey as beamcannon ProbableOwner

Updates BeamCannon particles